### PR TITLE
Make the end position coherent across modes (fix #34)

### DIFF
--- a/beginend.el
+++ b/beginend.el
@@ -155,6 +155,7 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
       (beginend--goto-nonwhitespace))))
 
 (declare-function dired-next-line "dired")
+(declare-function dired-move-to-filename "dired")
 
 (beginend-define-mode dired-mode
   (progn
@@ -170,7 +171,8 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
         (setf move (- move 1)))
       (dired-next-line move)))
   (progn
-    (beginend--goto-nonwhitespace)))
+    (beginend--goto-nonwhitespace)
+    (dired-move-to-filename)))
 
 (beginend-define-mode occur-mode
   (progn
@@ -210,18 +212,22 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
 (beginend-define-mode recentf-dialog-mode
   (progn
     (when (re-search-forward "^  \\[" nil t)
-      (goto-char (match-beginning 0))))
+      (goto-char (match-beginning 0))
+      (back-to-indentation)))
   (progn
-    (re-search-backward "^  \\[" nil t)))
+    (re-search-backward "^  \\[" nil t)
+    (back-to-indentation)))
 
 (declare-function org-agenda-next-item "org-agenda")
 (declare-function org-agenda-previous-item "org-agenda")
 
 (beginend-define-mode org-agenda-mode
   (progn
-    (org-agenda-next-item 1))
+    (org-agenda-next-item 1)
+    (back-to-indentation))
   (progn
-    (org-agenda-previous-item 1)))
+    (org-agenda-previous-item 1)
+    (back-to-indentation)))
 
 (declare-function compilation-next-error "compile")
 (declare-function compilation-previous-error "compile")
@@ -238,10 +244,10 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
 (beginend-define-mode notmuch-search-mode
   (progn
     (notmuch-search-first-thread)
-    (beginning-of-line))
+    (back-to-indentation))
   (progn
     (notmuch-search-last-thread)
-    (end-of-line)))
+    (back-to-indentation)))
 
 (beginend-define-mode elfeed-search-mode
   (progn)
@@ -253,9 +259,13 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
 
 (beginend-define-mode prodigy-mode
   (progn
-    (prodigy-first))
+    (prodigy-first)
+    (goto-char (line-beginning-position))
+    (back-to-indentation))
   (progn
-    (prodigy-last)))
+    (prodigy-last)
+    (goto-char (line-beginning-position))
+    (back-to-indentation)))
 
 (declare-function magit-section-backward "magit-section")
 
@@ -298,7 +308,8 @@ If optional argument P is present test at that point instead of `point'."
   (progn
     (while (not (or (bobp)
                     (beginend--prog-mode-code-position-p)))
-      (forward-line -1))))
+      (forward-line -1))
+    (goto-char (line-end-position))))
 
 
 

--- a/test/beginend-dired-test.el
+++ b/test/beginend-dired-test.el
@@ -59,7 +59,7 @@ SPEC is a list of symbols representing features to activate."
             (beginend-dired-mode-goto-beginning)
             (expect (looking-at "dir1") :to-be-truthy))
         (beginend-dired-mode-goto-end)
-        (expect (looking-back "dir2" 4) :to-be-truthy))
+        (expect (looking-at "dir2") :to-be-truthy))
       (kill-buffer))))
 
 (describe "beginend in a dired buffer"

--- a/test/beginend-prog-test.el
+++ b/test/beginend-prog-test.el
@@ -39,40 +39,40 @@
 
 (describe "buttercup"
   (describe "in prog-mode"
+    (before-each
+      (spy-on #'beginend--prog-mode-code-position-p
+              :and-call-fake (lambda ()
+                               (<= 3 (line-number-at-pos) 5))))
+
     (it "uses prog-mode-code-position-p to know where code begins"
       (with-temp-buffer
         (insert "line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
         (goto-char 2)
-        ;; workaround for https://github.com/jorgenschaefer/emacs-buttercup/issues/84
-        (cl-letf (((symbol-function 'beginend--prog-mode-code-position-p)
-                   (lambda ()
-                     (let ((line (line-number-at-pos)))
-                       (and (>= line 3) (<= line 5))))))
-          (beginend-prog-mode-goto-beginning))
-        (expect (looking-at "line3") :to-be-truthy)))
+        (beginend-prog-mode-goto-beginning)
+        (expect #'beginend--prog-mode-code-position-p :to-have-been-called)))
 
     (it "uses prog-mode-code-position-p to know where code end"
       (with-temp-buffer
         (insert "line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
         (goto-char 2)
+        (beginend-prog-mode-goto-end)
+        (expect #'beginend--prog-mode-code-position-p :to-have-been-called)))
+
+    (it "moves point to beginning of first code line"
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
+        (goto-char 2)
         ;; workaround for https://github.com/jorgenschaefer/emacs-buttercup/issues/84
-        (cl-letf (((symbol-function 'beginend--prog-mode-code-position-p)
-                   (lambda ()
-                     (let ((line (line-number-at-pos)))
-                       (and (>= line 3) (<= line 5))))))
-          (beginend-prog-mode-goto-end))
-        (expect (line-number-at-pos) :to-be 5)))
+        (beginend-prog-mode-goto-beginning)
+        (expect (line-number-at-pos) :to-be 3)
+        (expect (point) :to-be (line-beginning-position))))
 
     (it "moves point to end of last code line"
       (with-temp-buffer
         (insert "line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
         (goto-char 2)
         ;; workaround for https://github.com/jorgenschaefer/emacs-buttercup/issues/84
-        (cl-letf (((symbol-function 'beginend--prog-mode-code-position-p)
-                   (lambda ()
-                     (let ((line (line-number-at-pos)))
-                       (and (>= line 3) (<= line 5))))))
-          (beginend-prog-mode-goto-end))
+        (beginend-prog-mode-goto-end)
         (expect (line-number-at-pos) :to-be 5)
         (expect (point) :to-be (line-end-position)))))
 

--- a/test/beginend-prog-test.el
+++ b/test/beginend-prog-test.el
@@ -53,7 +53,7 @@
 
     (it "uses prog-mode-code-position-p to know where code end"
       (with-temp-buffer
-        (insert "line1\nline2\nline3\nline4\nline5\nline6\line7\n")
+        (insert "line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
         (goto-char 2)
         ;; workaround for https://github.com/jorgenschaefer/emacs-buttercup/issues/84
         (cl-letf (((symbol-function 'beginend--prog-mode-code-position-p)
@@ -61,7 +61,20 @@
                      (let ((line (line-number-at-pos)))
                        (and (>= line 3) (<= line 5))))))
           (beginend-prog-mode-goto-end))
-        (expect (looking-at "line5") :to-be-truthy))))
+        (expect (line-number-at-pos) :to-be 5)))
+
+    (it "moves point to end of last code line"
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
+        (goto-char 2)
+        ;; workaround for https://github.com/jorgenschaefer/emacs-buttercup/issues/84
+        (cl-letf (((symbol-function 'beginend--prog-mode-code-position-p)
+                   (lambda ()
+                     (let ((line (line-number-at-pos)))
+                       (and (>= line 3) (<= line 5))))))
+          (beginend-prog-mode-goto-end))
+        (expect (line-number-at-pos) :to-be 5)
+        (expect (point) :to-be (line-end-position)))))
 
   (describe "beginend--prog-mode-code-position-p"
     (it "returns non-nil for a line of code"


### PR DESCRIPTION
The principle is:

- when the mode shows a list of items, going to the end should go to
  the beginning of the last item;

- otherwise, going to the end should go to the end of the last line.