### PR TITLE
adds `beginend-define-mode` for `deft-mode`

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,6 +37,7 @@ In particular, these modes are supported:
 | *notmuch-search-mode* | first thread            | last thread                |
 | *elfeed-mode*         | first feed              | last feed                  |
 | *prodigy-mode*        | first service           | last service               |
+| *deft-mode*           | first match             | last match                 |
 
 Finally, beginend does what you expect when your buffer is narrowed.
 

--- a/beginend.el
+++ b/beginend.el
@@ -283,6 +283,13 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
     (magit-section-backward)
     (magit-section-backward)))
 
+(beginend-define-mode deft-mode
+  (progn
+    (re-search-forward "^$")
+    (forward-line))
+  (progn
+    (forward-line -1)))
+
 (defun beginend--point-is-in-comment-p (&optional p)
   "Return non-nil if point is in comment.
 


### PR DESCRIPTION
Hi,

I would like to use `beginend` with [deft](https://github.com/jrblevin/deft).
Would you welcome this pr?

Best