### PR TITLE
In elfeed search buffers go to line -1 from the end, not -2

### DIFF
--- a/beginend.el
+++ b/beginend.el
@@ -258,7 +258,7 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
 (beginend-define-mode elfeed-search-mode
   (progn)
   (progn
-    (forward-line -2)))
+    (forward-line -1)))
 
 (declare-function prodigy-first "prodigy")
 (declare-function prodigy-last "prodigy")


### PR DESCRIPTION
The current (forward-line -2) puts point on the next to last entry in
the search buffer, instead of on the last item. With this change point
goes to the last entry instead.

[I imagine that probably elfeed-search buffers used to end in TWO
non-entry lines, which is why beginend had a -2, but then at some
point elfeed changed to have only one blank line at the end. This is
just speculation, but seems very likely.]