### PR TITLE
Add support for elfeed-show-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,6 +34,7 @@ In particular, these modes are supported:
 | *deft-mode*           | first match             | last match                 |
 | *dired-mode*          | first file              | last file                  |
 | *elfeed-search-mode*  | first feed              | last feed                  |
+| *elfeed-show-mode*    | first body line         | end of buffer              |
 | *epa-key-list-mode*   | first key               | last key                   |
 | *ibuffer-mode*        | first buffer            | last buffer                |
 | *laTeX-mode*          | =\begin{document}=      | =\end{document}=           |

--- a/beginend.el
+++ b/beginend.el
@@ -270,6 +270,12 @@ BEGIN-BODY and END-BODY are two `progn' expressions passed to respectively
   (progn
     (forward-line -1)))
 
+(beginend-define-mode elfeed-show-mode
+  (progn
+    (re-search-forward "^Link:")
+    (forward-line))
+  (progn))
+
 (declare-function prodigy-first "prodigy")
 (declare-function prodigy-last "prodigy")
 


### PR DESCRIPTION
This patch adds support for `elfeed-show-mode` by teaching beginend how to move point to the beginning of the body of the article.

The headers listed in `elfeed-show-mode` [seem to be static](https://github.com/skeeto/elfeed/blob/master/elfeed-show.el#L176) (non-customisable) and `Link:` is always the last one (and must exist) so using it as a way to find the end of the headers sounds safe to me.