### PR TITLE
Handle file-level docstrings in prog-mode

### DIFF
--- a/beginend.el
+++ b/beginend.el
@@ -332,10 +332,27 @@ If optional argument P is present test at that point instead of `point'."
                   (and (/= 0 (logand (ash 1 17) s))
                        (nth 4 (syntax-ppss (+ p 1)))))))))))
 
+(defun beginend--point-is-in-string-p (&optional p)
+  "Return non-nil if point is in string.
+
+If optional argument P is present test at that point instead of `point'."
+  (setq p (or p (point)))
+  (ignore-errors
+    (save-excursion
+      (or (nth 3 (syntax-ppss p))
+          (eq (char-syntax (char-after p)) ?\")
+          (let ((s (car (syntax-after p))))
+            (when s
+              (or (and (/= 0 (logand (ash 1 16) s))
+                       (nth 3 (syntax-ppss (+ p 2))))
+                  (and (/= 0 (logand (ash 1 17) s))
+                       (nth 3 (syntax-ppss (+ p 1)))))))))))
+
 (defun beginend--prog-mode-code-position-p ()
   "Return non-nil if point, at beginning of line, is inside code."
   (not
    (or (beginend--point-is-in-comment-p)
+       (beginend--point-is-in-string-p)
        (= (point) (line-end-position))
        (looking-at (char-to-string ?\f))))) ;; form-feed (^L)
 

--- a/test/beginend-prog-test.el
+++ b/test/beginend-prog-test.el
@@ -82,10 +82,18 @@
         (expect (beginend--prog-mode-code-position-p) :to-be-truthy)))
 
     (describe "returns nil"
-      (it "for a line of comment"
+      (it "for a comment line"
         (with-temp-buffer
           (emacs-lisp-mode)
           (insert ";; (defvar foo 3)\n")
+          (font-lock-ensure)
+          (goto-char (point-min))
+          (expect (beginend--prog-mode-code-position-p) :to-be nil)))
+
+      (it "for a docstring"
+        (with-temp-buffer
+          (emacs-lisp-mode)
+          (insert "\"This is a file-level docstring.\"\n")
           (font-lock-ensure)
           (goto-char (point-min))
           (expect (beginend--prog-mode-code-position-p) :to-be nil)))


### PR DESCRIPTION
Closes #77.

This seems to work in a python file with a file level docstring.

As you'll see I really just adapted the existing `beginend--point-is-in-comment-p` (private) function. Not sure if I fully understand the `let` form yet so it may not be necessary in `beginend--point-is-in-string-p`. Plus you may not like this solution as it probably goes against the principles of the DRY methodology.

Not entirely sure how I should run the tests. I executed `buttercup-run-at-point` at the top level `describe` form in `beginend-prog-test.el` which resulted in the following output. Perhaps `buttercup` should have a `buttercup-run-on-buffer` type command as well. The individual test times are interesting. I added the new "for a docstring" test.

````
Running 9 specs.

beginend
  in prog-mode
    uses prog-mode-code-position-p to know where code begins (0.57ms)
    uses prog-mode-code-position-p to know where code end (0.39ms)
    moves point to beginning of first code line (0.77ms)
    moves point to end of last code line (0.57ms)
  beginend--prog-mode-code-position-p
    returns non-nil for a line of code (3.75ms)
    returns nil
      for a comment line (2.74ms)
      for a docstring (2.64ms)
      for an empty line (3.10ms)
      for a line with ^L (2.81ms)

Ran 9 specs, 0 failed, in 18.51ms.
````

The [`buttercup docs`](https://github.com/jorgenschaefer/emacs-buttercup/blob/master/docs/running-tests.md) only document running tests when using `cask`, `eldev`, and `eask` but I think you use `makel.mk` right? 

Since you use `buttercup` why do you need the `.ert-runner` file? Is it because you refer to `${TEST_ERT_FILES}` in your Makefile. Excuse my ignorance here.

Finally, I noted the following comment at several places in `begined-prog-test.el`:

````Emacs-Lisp
;; workaround for https://github.com/jorgenschaefer/emacs-buttercup/issues/84
````
But if understand the exchange in that issue then these comments are obsolete as you have put `spy-on` in a `before-each` form. I have left them in for now but can remove them if you agree.